### PR TITLE
Add onboarding prompt with categories

### DIFF
--- a/src/components/ChatBot.tsx
+++ b/src/components/ChatBot.tsx
@@ -20,10 +20,11 @@ export const ChatBot: React.FC = () => {
 
   // Example questions for empty state
   const exampleQuestions = [
-    "What services does Pixl offer to support new brands?",
-    "How does Invespy help with off-plan real estate sales or marketing?",
-    "Can you explain your full-service agency approach?",
-    "What makes Pixl and Invespy unique in the UAE market?",
+    "Broker",
+    "Real Estate Developer",
+    "Applicant",
+    "Vendor/Partner",
+    "Other",
   ];
 
   // API chat handler with streaming support
@@ -123,10 +124,14 @@ export const ChatBot: React.FC = () => {
         {messages.length === 0 && (
           <div className="flex flex-col items-center mt-20 text-center space-y-5">
             <div className="text-lg font-semibold text-gray-700 dark:text-blue-100">
-              Hello, I am the AI assistant for{" "}
-              <span className="text-indigo-700 dark:text-blue-300 font-bold">Pixl</span> and{" "}
-              <span className="text-indigo-700 dark:text-blue-300 font-bold">Invespy</span>.<br />
-              Tell me what you would like to know!
+              👋 Welcome to Pixl.ae — Where Ideas Become Iconic.<br />
+              What best describes you?<br />
+              <span className="text-indigo-700 dark:text-blue-300 font-bold">Broker</span>,{' '}
+              <span className="text-indigo-700 dark:text-blue-300 font-bold">Real Estate Developer</span>,{' '}
+              <span className="text-indigo-700 dark:text-blue-300 font-bold">Applicant</span>,{' '}
+              <span className="text-indigo-700 dark:text-blue-300 font-bold">Vendor/Partner</span>{' '}
+              or{' '}
+              <span className="text-indigo-700 dark:text-blue-300 font-bold">Other</span>?
             </div>
             <div className="flex flex-col items-center gap-2 mt-4">
               {exampleQuestions.map((q) => (

--- a/src/lib/systemPrompt.ts
+++ b/src/lib/systemPrompt.ts
@@ -66,6 +66,15 @@ For data insights, analytics, or pricing trends, use the Invespy.io platform's i
 💡Behavior Rules:
 Always identify which domain your answer is sourced from.
 
+Start each conversation with:
+"Welcome to Pixl.ae — Where Ideas Become Iconic. What best describes you? Broker, Real Estate Developer, Applicant, Vendor/Partner or Other?"
+
+If the user doesn't specify a category, assume "Other" and follow the Other flow:
+- Ask: "Please tell us how we can help."
+- Offer to receive links or files.
+- Collect their name and email for follow-up.
+- Then thank them politely.
+
 If a question is outside your training data, politely say so and guide the user to visit https://www.pixl.ae or https://www.invespy.com.
 
 When discussing data or trends, clarify if the insights are derived from Invespy.io.


### PR DESCRIPTION
## Summary
- show greeting with role categories
- present categories as example buttons
- mention onboarding flow in system prompt

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866592e9e84832f95a32902f3175a5a